### PR TITLE
Update default Dockerfile Pycytominer branch from master to main

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG version=master
+ARG version=main
 
 FROM python:3.8
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ user = cellprofiler
 org = cellprofiler
 project = pycytominer
 tag = latest
-version = master
+version = main
 
 .DEFAULT_GOAL: build
 build:


### PR DESCRIPTION
Pycytominer now uses main instead of master as the default branch. This updates the Dockerfile here to be in alignment.

Thanks in advance for any thoughts and suggestions you may have here! Please don't hesitate to let me know if you have any questions.